### PR TITLE
use gazelle to generate go bazel build files.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -467,7 +467,6 @@ copy_to_bin(
     visibility = ["//visibility:public"],
 )
 
-
 # copy_to_directory(
 #     name = "copy-godel-0.3-lib",
 #     srcs = [
@@ -703,8 +702,8 @@ pkg_tar(
     strip_prefix = strip_prefix.from_pkg(),
     visibility = ["//visibility:public"],
     deps = [
-        ":sparrow-cli-pkg",
         ":coref-cfamily-src-extractor-pkg",
+        ":sparrow-cli-pkg",
     ],
 )
 
@@ -726,4 +725,4 @@ pkg_tar(
 #         "-build_file_proto_mode=disable_global",
 #     ],
 #     command = "update-repos",
-# )
+# )   

--- a/language/go/extractor/BUILD
+++ b/language/go/extractor/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix alipay.com/code_insight/coref-go-extractor
+gazelle(name = "gazelle")
+
+go_library(
+    name = "coref-go-extractor_lib",
+    srcs = ["main.go"],
+    importpath = "alipay.com/code_insight/coref-go-extractor",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//language/go/extractor/src/config",
+        "//language/go/extractor/src/core",
+    ],
+)
+
+go_binary(
+    name = "extractor",
+    embed = [":coref-go-extractor_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/language/go/extractor/src/cli/BUILD.bazel
+++ b/language/go/extractor/src/cli/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "cli_lib",
+    srcs = [
+        "extractor_cli.go",
+        "helper.go",
+    ],
+    importpath = "alipay.com/code_insight/coref-go-extractor/src/cli",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//language/go/extractor/src/config",
+        "//language/go/extractor/src/core",
+        "//language/go/extractor/src/util",
+        "@org_golang_x_mod//semver",
+    ],
+)
+
+go_binary(
+    name = "cli",
+    embed = [":cli_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/language/go/extractor/src/config/BUILD.bazel
+++ b/language/go/extractor/src/config/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "config",
+    srcs = ["config.go"],
+    importpath = "alipay.com/code_insight/coref-go-extractor/src/config",
+    visibility = ["//visibility:public"],
+)

--- a/language/go/extractor/src/core/BUILD.bazel
+++ b/language/go/extractor/src/core/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "core",
+    srcs = [
+        "extract_file.go",
+        "extract_mod.go",
+        "extract_pkg.go",
+        "extraction.go",
+        "label.go",
+        "profile.go",
+    ],
+    importpath = "alipay.com/code_insight/coref-go-extractor/src/core",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//language/go/extractor/src/config",
+        "//language/go/extractor/src/orm",
+        "//language/go/extractor/src/util",
+        "@io_gorm_gorm//:gorm",
+        "@org_golang_x_mod//modfile",
+        "@org_golang_x_tools//go/packages",
+        "@org_modernc_mathutil//:mathutil",
+    ],
+)

--- a/language/go/extractor/src/orm/BUILD.bazel
+++ b/language/go/extractor/src/orm/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "orm",
+    srcs = [
+        "data_decl.go",
+        "data_types.go",
+        "db_model.go",
+        "db_writer.go",
+    ],
+    importpath = "alipay.com/code_insight/coref-go-extractor/src/orm",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_glebarez_sqlite//:sqlite",
+        "@io_gorm_gorm//:gorm",
+        "@io_gorm_gorm//logger",
+        "@io_gorm_gorm//schema",
+        "@org_golang_x_tools//go/packages",
+    ],
+)

--- a/language/go/extractor/src/util/BUILD.bazel
+++ b/language/go/extractor/src/util/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "util",
+    srcs = [
+        "setup.go",
+        "util.go",
+    ],
+    importpath = "alipay.com/code_insight/coref-go-extractor/src/util",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "util_test",
+    srcs = ["util_test.go"],
+    embed = [":util"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/language/java/extractor/BUILD
+++ b/language/java/extractor/BUILD
@@ -127,4 +127,3 @@ genrule(
         "@maven//:org_xerial_sqlite_jdbc",
     ],
 )
-

--- a/language/python/BUILD
+++ b/language/python/BUILD
@@ -1,4 +1,3 @@
-
 # Using filegroup is encouraged instead of referencing directories directly. The latter is unsound.
 # When combined with glob, filegroup can ensure that all files are explicitly known to the build system.
 filegroup(

--- a/language/python/extractor/BUILD
+++ b/language/python/extractor/BUILD
@@ -1,13 +1,11 @@
 load("//:visibility.bzl", "PUBLIC_VISIBILITY")
-
 load("@rules_python//python:defs.bzl", "py_runtime_pair")
-
 load("@python3_10//:defs.bzl", "interpreter")
 
 py_runtime(
     name = "my_py3_runtime",
+    interpreter = interpreter,
     python_version = "PY3",
-    interpreter = interpreter
 )
 
 #py_runtime_pair(
@@ -26,9 +24,7 @@ package(
 )
 
 load("@deps//:requirements.bzl", "requirement")
-
 load("@rules_python//python:defs.bzl", "py_library")
-
 
 #py_binary(
 #    name = "coref-python-src-extractor1",
@@ -45,7 +41,10 @@ load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
     name = "test",
-    srcs = glob(["src/**/*.py"], exclude=["**/tests/**"]),
+    srcs = glob(
+        ["src/**/*.py"],
+        exclude = ["**/tests/**"],
+    ),
     visibility = ["//visibility:public"],
     deps = [
         requirement("tqdm"),
@@ -60,7 +59,6 @@ filegroup(
         "src/auto_build.py",
     ],
 )
-
 
 genrule(
     name = "test1",
@@ -77,8 +75,6 @@ genrule(
     $(PYTHON3) $(locations //language/python/extractor:install_source)
     cp language/python/extractor/src/dist/coref-python-src-extractor $(RULEDIR)
     """,
-    toolchains=["@rules_python//python:current_py_toolchain",],
+    toolchains = ["@rules_python//python:current_py_toolchain"],
     visibility = ["//visibility:public"],
 )
-
-


### PR DESCRIPTION
Now we can build go extractor in public environment.
1. use gazelle to generate go extractor's bazel build files.
2. gazelle will beautify all bazel build files.
3. if go extractor changes, run command ```bazel run //language/go/extractor:gazelle``` to re-generate bazel build files.