### PR TITLE
[feat] improve inst combine pass, optimize generated soufflé code

### DIFF
--- a/godel-script/README.md
+++ b/godel-script/README.md
@@ -79,10 +79,8 @@ git reset HEAD~
 Use command below:
 
 ```bash
-mkdir build
-cd build
-cmake ..
-make -j
+mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j6
 ```
 
 After building, you'll find `build/godel` in the `build` folder.
@@ -91,20 +89,18 @@ After building, you'll find `build/godel` in the `build` folder.
 
 Use this command for help:
 
-> ./build/godel -h
+> godel -h
 
-### Compile Target Soufflé
+### Compile GödelScript to Target Soufflé
 
-> ./build/godel -p {godel library directory} {input file} -s {soufflé output file} -Of
+> godel -p {godel library directory} {input file} -s {soufflé output file} -O2
 
-`-Of` is an optimization for join order, we suggest to switch it on.
+We suggest to use `-O2` for stable optimizations.
 
-### Directly Run Soufflé
+### Directly Run GödelScript
 
-> ./build/godel -p {godel library directory} {input file} -r -Of -f {database directory}
+> godel -p {godel library directory} {input file} -r -O2 -f {database directory}
 
-`-Of` is an optimization for join order, we suggest to switch it on.
+We suggest to use `-O2` for stable optimizations.
 
 `-r` means directly run soufflé.
-
-`-v` could be used for getting verbose info.

--- a/godel-script/godel-frontend/src/error/error.cpp
+++ b/godel-script/godel-frontend/src/error/error.cpp
@@ -231,13 +231,13 @@ void error::warn_ignored_DO_schema(const std::unordered_set<std::string>& vec) {
     size_t ignored_count = 0;
     for(const auto& i : vec) {
         ++ignored_count;
-        if (ignored_count > 4) {
+        if (ignored_count > 8) {
             break;
         }
         std::clog << reset << "  " << i << "\n";
     }
-    if (vec.size() > 4) {
-        std::clog << reset << "  ...(" << vec.size()-4 << ")\n";
+    if (vec.size() > 8) {
+        std::clog << reset << "  ...(" << vec.size() - 8 << ")\n";
     }
     std::clog << std::endl;
 }

--- a/godel-script/godel-frontend/src/ir/inst_combine.h
+++ b/godel-script/godel-frontend/src/ir/inst_combine.h
@@ -23,6 +23,7 @@ private:
 
 private:
     void scan(souffle_rule_impl*);
+    void run_on_single_impl(souffle_rule_impl*);
 
 public:
     inst_combine_pass(ir_context& c): pass(pass_kind::ps_inst_combine, c) {}
@@ -65,6 +66,7 @@ public:
 class inst_elimination_worker: public lir::inst_visitor {
 private:
     std::vector<lir::block*> blk;
+    size_t eliminated_count = 0;
 
 private:
     void visit_boolean(lir::boolean* node) override {
@@ -111,6 +113,9 @@ private:
 
 public:
     void copy(souffle_rule_impl*);
+    auto get_eliminated_count() const {
+        return eliminated_count;
+    }
 };
 
 }

--- a/godel-script/godel-frontend/src/ir/inst_combine.h
+++ b/godel-script/godel-frontend/src/ir/inst_combine.h
@@ -20,6 +20,7 @@ private:
 private:
     void visit_store(lir::store*) override;
     void visit_compare(lir::compare*) override;
+    void visit_call(lir::call*) override;
 
 private:
     void scan(souffle_rule_impl*);

--- a/godel-script/godel-frontend/src/ir/inst_combine.h
+++ b/godel-script/godel-frontend/src/ir/inst_combine.h
@@ -118,4 +118,16 @@ public:
     }
 };
 
+class replace_find_call: public pass {
+private:
+    void visit_block(lir::block*) override;
+
+public:
+    replace_find_call(ir_context& c): pass(pass_kind::ps_replace_find_call, c) {}
+    const char* get_name() const override {
+        return "[Transform] Replace Find Call";
+    }
+    bool run() override;
+};
+
 }

--- a/godel-script/godel-frontend/src/ir/ir_gen.h
+++ b/godel-script/godel-frontend/src/ir/ir_gen.h
@@ -226,9 +226,14 @@ private:
                              std::vector<lir::call*>&,
                              bool);
     bool visit_for_stmt(for_stmt*) override;
+    // adjust order of generated IR, to change the join order, make it running faster
+    // for statement often uses a large set, so this optimization is useful in most cases
     void optimized_for_stmt_gen(for_stmt*);
     void unoptimized_for_stmt_gen(for_stmt*);
     bool visit_let_stmt(let_stmt*) override;
+    // adjust order of generated IR, to change the join order, make it running faster
+    // let statement often uses single value or a small set
+    // so this optimization is not very useful, or even harmful
     void optimized_let_stmt_gen(let_stmt*);
     void unoptimized_let_stmt_gen(let_stmt*);
 

--- a/godel-script/godel-frontend/src/ir/pass.h
+++ b/godel-script/godel-frontend/src/ir/pass.h
@@ -13,6 +13,7 @@ enum class pass_kind {
     ps_remove_unused,
     ps_remove_unused_type,
     ps_inst_combine,
+    ps_replace_find_call,
     ps_flatten_nested_block,
     ps_aggregator_inline_remark,
     ps_ungrounded_check,

--- a/godel-script/godel-frontend/src/ir/pass_manager.cpp
+++ b/godel-script/godel-frontend/src/ir/pass_manager.cpp
@@ -29,6 +29,7 @@ void pass_manager::run(ir_context& ctx, const cli::configure& conf) {
         ordered_pass_list.push_back(new unused_type_alias_remove_pass(ctx));
     }
     if (!conf.count(cli::option::cli_disable_inst_combine)) {
+        ordered_pass_list.push_back(new replace_find_call(ctx));
         ordered_pass_list.push_back(new inst_combine_pass(ctx));
     }
     ordered_pass_list.push_back(new flatten_nested_block(ctx));

--- a/godel-script/godel-frontend/src/sema/ungrounded_checker.cpp
+++ b/godel-script/godel-frontend/src/sema/ungrounded_checker.cpp
@@ -405,7 +405,12 @@ bool ungrounded_parameter_checker::check_non_binding_binary_operator(binary_oper
     return node->get_operator_type() == binary_operator::type::add ||
            node->get_operator_type() == binary_operator::type::sub ||
            node->get_operator_type() == binary_operator::type::mult ||
-           node->get_operator_type() == binary_operator::type::div;
+           node->get_operator_type() == binary_operator::type::div ||
+           node->get_operator_type() == binary_operator::type::compare_not_equal ||
+           node->get_operator_type() == binary_operator::type::compare_less ||
+           node->get_operator_type() == binary_operator::type::compare_less_equal ||
+           node->get_operator_type() == binary_operator::type::compare_great ||
+           node->get_operator_type() == binary_operator::type::compare_great_equal;
 }
 
 bool ungrounded_parameter_checker::visit_call_expr(call_expr* node) {


### PR DESCRIPTION
inst combine pass will iterate multiple times to make sure necessary combinations are done.

for example:

```rust
(
  GF_4A_id(ssa_temp_2, a),
  ssa_temp_2 != 1,
  R_1A7__all__(ssa_temp_4),
  (ssa_temp_5 = ssa_temp_4, ssa_temp_4 = a),
  GF_4A_id(ssa_temp_6, ssa_temp_5),
  ssa_temp_6 != 1,
  1 = 1
)
```

will be optimized to:

```rust
(
  GF_4A_id(ssa_temp_2, a),
  ssa_temp_2 != 1,
  R_1A7__all__(a),
  GF_4A_id(ssa_temp_6, a),
  ssa_temp_6 != 1
)
```

for `ssa_temp_5` is replaced with `ssa_temp_4` at first iteration, and `ssa_temp_4` is replaced with `a` at next iteration.