### PR TITLE
fix run sparrow for compatibility with Bash syntax

### DIFF
--- a/cli/sparrow
+++ b/cli/sparrow
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # A convenient method to return the actual path even for non symlinks
 # and multi-level symlinks.


### PR DESCRIPTION
修复sparrow运行在Ubuntu 22.04.5 LTS脚本执行错误 https://github.com/codefuse-ai/CodeFuse-Query/issues/112
